### PR TITLE
difyバージョンを1.1.3に更新

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -14,7 +14,7 @@ new DifyOnAwsStack(app, 'DifyOnAwsStack', {
   // Allow access from the Internet. Narrow this down if you want further security.
   allowedCidrs: ['0.0.0.0/0'],
   difyImageTag: '1.1.3',
-  difySandboxImageTag: '1.1.3',
+  difySandboxImageTag: '0.2.11',
 });
 
 // cdk.Aspects.of(app).add(new AwsPrototypingChecks());

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -13,7 +13,8 @@ new DifyOnAwsStack(app, 'DifyOnAwsStack', {
   },
   // Allow access from the Internet. Narrow this down if you want further security.
   allowedCidrs: ['0.0.0.0/0'],
-  difyImageTag: '0.8.3',
+  difyImageTag: '1.1.3',
+  difySandboxImageTag: '1.1.3',
 });
 
 // cdk.Aspects.of(app).add(new AwsPrototypingChecks());

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -95,8 +95,8 @@ export class DifyOnAwsStack extends cdk.Stack {
     super(scope, id, props);
 
     const {
-      difyImageTag: imageTag = 'latest',
-      difySandboxImageTag: sandboxImageTag = 'latest',
+      difyImageTag: imageTag = '1.1.3',
+      difySandboxImageTag: sandboxImageTag = '1.1.3',
       allowAnySyscalls = false,
     } = props;
 

--- a/lib/dify-on-aws-stack.ts
+++ b/lib/dify-on-aws-stack.ts
@@ -95,8 +95,8 @@ export class DifyOnAwsStack extends cdk.Stack {
     super(scope, id, props);
 
     const {
-      difyImageTag: imageTag = '1.1.3',
-      difySandboxImageTag: sandboxImageTag = '1.1.3',
+      difyImageTag: imageTag = 'latest',
+      difySandboxImageTag: sandboxImageTag = 'latest',
       allowAnySyscalls = false,
     } = props;
 


### PR DESCRIPTION
difyのバージョンを更新しました。\n\n- difyImageTagを0.8.3から1.1.3に変更\n- difySandboxImageTagを0.2.11に設定